### PR TITLE
Handle class not found fatal error with spl_autoload_register

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,4 @@
 /phpstan.neon export-ignore
 /spec/ export-ignore
 /CONTRIBUTING.md export-ignore
+/kahlan-config.php export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage.json
 bin
 .php_cs.cache
 .vscode/
+build/logs/*

--- a/kahlan-config.php
+++ b/kahlan-config.php
@@ -1,0 +1,17 @@
+<?php // kahlan-config.php
+
+use App\Kernel;
+use Kahlan\Filter\Filters;
+
+Filters::apply($this, 'bootstrap', function($next) {
+
+    require __DIR__ . '/vendor/autoload.php';
+
+    $root = $this->suite()->root();
+    $root->beforeAll(function () {
+//        allow('spl_autoload_register')->toBeCalled()->andReturn(null);
+    });
+
+    return $next();
+
+});

--- a/kahlan-config.php
+++ b/kahlan-config.php
@@ -1,17 +1,23 @@
 <?php // kahlan-config.php
 
-use App\Kernel;
 use Kahlan\Filter\Filters;
+use Kahlan\Reporter\Coverage;
+use Kahlan\Reporter\Coverage\Driver\Xdebug;
 
-Filters::apply($this, 'bootstrap', function($next) {
+Filters::apply($this, 'coverage', function($next) {
+    if (! extension_loaded('xdebug')) {
+        return;
+    }
 
-    require __DIR__ . '/vendor/autoload.php';
-
-    $root = $this->suite()->root();
-    $root->beforeAll(function () {
-//        allow('spl_autoload_register')->toBeCalled()->andReturn(null);
-    });
-
-    return $next();
-
+    $reporters = $this->reporters();
+    $coverage = new Coverage([
+        'verbosity' => $this->commandLine()->get('coverage'),
+        'driver'    => new Xdebug(),
+        'path'      => $this->commandLine()->get('src'),
+        'exclude'   => [
+            'src/HeroAutoload.php',
+        ],
+        'colors'    => ! $this->commandLine()->get('no-colors')
+    ]);
+    $reporters->add('coverage', $coverage);
 });

--- a/src/HeroAutoload.php
+++ b/src/HeroAutoload.php
@@ -14,6 +14,18 @@ class HeroAutoload
             return;
         }
 
+        if (\in_array(
+            $class,
+            [
+                'error_reporting',
+                'error_get_last',
+                'ErrorHeroModuleLogger',
+                'ZendDeveloperTools\\ProfilerEvent',
+            ]
+        )) {
+            return;
+        }
+
         throw new RuntimeException(sprintf(
             'class %s not found',
             $class

--- a/src/HeroAutoload.php
+++ b/src/HeroAutoload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ErrorHeroModule;
+
+use RuntimeException;
+
+class HeroAutoload
+{
+    public static function handle(string $class)
+    {
+        if (\class_exists($class)) {
+            return;
+        }
+
+        throw new RuntimeException(sprintf(
+            'class %s not found',
+            $class
+        ));
+    }
+}

--- a/src/Listener/Mvc.php
+++ b/src/Listener/Mvc.php
@@ -57,7 +57,7 @@ class Mvc extends AbstractListenerAggregate
     {
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);
-        //\spl_autoload_register([HeroAutoload::class, 'handle']);
+        \spl_autoload_register([HeroAutoload::class, 'handle']);
     }
 
     public function exceptionError(MvcEvent $e) : void

--- a/src/Listener/Mvc.php
+++ b/src/Listener/Mvc.php
@@ -6,6 +6,7 @@ namespace ErrorHeroModule\Listener;
 
 use Assert\Assertion;
 use ErrorHeroModule\Handler\Logging;
+use ErrorHeroModule\HeroAutoload;
 use ErrorHeroModule\HeroTrait;
 use Zend\Console\Response as ConsoleResponse;
 use Zend\EventManager\AbstractListenerAggregate;
@@ -56,6 +57,7 @@ class Mvc extends AbstractListenerAggregate
     {
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);
+        //\spl_autoload_register([HeroAutoload::class, 'handle']);
     }
 
     public function exceptionError(MvcEvent $e) : void

--- a/src/Middleware/Expressive.php
+++ b/src/Middleware/Expressive.php
@@ -61,7 +61,7 @@ class Expressive implements MiddlewareInterface
     {
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);
-        //\spl_autoload_register([HeroAutoload::class, 'handle']);
+        \spl_autoload_register([HeroAutoload::class, 'handle']);
     }
 
     /**

--- a/src/Middleware/Expressive.php
+++ b/src/Middleware/Expressive.php
@@ -7,6 +7,7 @@ namespace ErrorHeroModule\Middleware;
 use Closure;
 use Error;
 use ErrorHeroModule\Handler\Logging;
+use ErrorHeroModule\HeroAutoload;
 use ErrorHeroModule\HeroTrait;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
@@ -60,6 +61,7 @@ class Expressive implements MiddlewareInterface
     {
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);
+        //\spl_autoload_register([HeroAutoload::class, 'handle']);
     }
 
     /**


### PR DESCRIPTION
for example:

```php
class Foo extends NotExistenceClass{}
```

This now handled and logged.