### PR TITLE
ensure \ob_end_flush() while ob_get_level() > 0 before \ob_start()   

### DIFF
--- a/src/Listener/Mvc.php
+++ b/src/Listener/Mvc.php
@@ -66,6 +66,10 @@ class Mvc extends AbstractListenerAggregate
             \ini_set('display_errors', '0');
         }
 
+        while (\ob_get_level() > 0) {
+            \ob_end_flush();
+        }
+
         \ob_start([$this, 'phpFatalErrorHandler']);
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);

--- a/src/Middleware/Expressive.php
+++ b/src/Middleware/Expressive.php
@@ -69,6 +69,10 @@ class Expressive implements MiddlewareInterface
             \ini_set('display_errors', '0');
         }
 
+        while (\ob_get_level() > 0) {
+            \ob_end_flush();
+        }
+
         \ob_start([$this, 'phpFatalErrorHandler']);
         \register_shutdown_function([$this, 'execOnShutdown']);
         \set_error_handler([$this, 'phpErrorHandler']);


### PR DESCRIPTION
to flush and turn off existing active output buffering if any.