### PR TITLE
added ability to exclude specific PHP E_* error and Exception with only for specific message provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Features
 
 - [x] Save to DB with Db Writer Adapter.
 - [x] Log Exception (dispatch.error and render.error) and PHP Errors in all events process.
-- [x] Support excludes [PHP E_* Error](http://www.php.net/manual/en/errorfunc.constants.php) (eg: exclude E_USER_DEPRECATED) in config settings.
-- [x] Support excludes [PHP Exception](http://php.net/manual/en/spl.exceptions.php) (eg: Exception class or classes that extends it) in config settings.
+- [x] Support excludes [PHP E_* Error](http://www.php.net/manual/en/errorfunc.constants.php) (eg: exclude E_USER_DEPRECATED or specific E_USER_DEPRECATED with specific message) in config settings.
+- [x] Support excludes [PHP Exception](http://php.net/manual/en/spl.exceptions.php) (eg: Exception class or classes that extends it or specific exception class with specific message) in config settings.
 - [x] Handle only once log error for same error per configured time range.
 - [x] Set default page (web access) or default message (console access) for error if configured 'display_errors' = 0.
 - [x] Set default content when request is XMLHttpRequest via 'ajax' configuration.
@@ -200,12 +200,27 @@ return [
 
             // excluded php errors ( http://www.php.net/manual/en/errorfunc.constants.php )
             'exclude-php-errors' => [
+
+                // can be specific error
                 \E_USER_DEPRECATED,
+
+                // can be specific error with specific message
+                [\E_WARNING, 'specific error message'],
+
             ],
 
             // excluded exceptions
             'exclude-exceptions' => [
-                \App\Exception\MyException::class, // can be an Exception class or class extends Exception class
+
+                // can be an Exception class or class extends Exception class
+                \App\Exception\MyException::class,
+
+                // can be specific exception with specific message
+                [\RuntimeException::class, 'specific exception message'],
+
+                // or specific Error class with specific message
+                [\Error::class, 'specific error message'],
+
             ],
 
             // show or not error

--- a/config/expressive-error-hero-module.local.php.dist
+++ b/config/expressive-error-hero-module.local.php.dist
@@ -49,14 +49,29 @@ return [
 
         'display-settings' => [
 
-            // excluded php errors
+            // excluded php errors ( http://www.php.net/manual/en/errorfunc.constants.php )
             'exclude-php-errors' => [
-                \E_USER_DEPRECATED
+
+                // can be specific error
+                \E_USER_DEPRECATED,
+
+                // can be specific error with specific message
+                [\E_WARNING, 'specific error message'],
+
             ],
 
             // excluded exceptions
             'exclude-exceptions' => [
-                \App\Exception\MyException::class, // can be an Exception class or class extends Exception class
+
+                // can be an Exception class or class extends Exception class
+                \App\Exception\MyException::class,
+
+                // can be specific exception with specific message
+                [\RuntimeException::class, 'specific exception message'],
+
+                // or specific Error class with specific message
+                [\Error::class, 'specific error message'],
+
             ],
 
             // show or not error

--- a/spec/Fixture/config/autoload-for-specific-error-and-exception/error-hero-module.local.php
+++ b/spec/Fixture/config/autoload-for-specific-error-and-exception/error-hero-module.local.php
@@ -4,6 +4,16 @@ use Zend\Db\Adapter\AdapterInterface;
 
 return [
 
+    'db' => [
+        'username' => 'root',
+        'password' => '',
+        'driver' => 'Pdo',
+        'dsn' => 'mysql:dbname=errorheromodule;host=127.0.0.1',
+        'driver_options' => [
+            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'UTF8\'',
+        ],
+    ],
+
     'log' => [
         'ErrorHeroModuleLogger' => [
             'writers' => [
@@ -26,12 +36,6 @@ return [
                                 'request_data' => 'request_data',
                             ],
                         ],
-                        'formatter' => [
-                            'name' => 'db',
-                            'options' => [
-                                'dateTimeFormat' => 'Y-m-d H:i:s',
-                            ],
-                        ],
                     ],
                 ],
 
@@ -40,42 +44,25 @@ return [
     ],
 
     'error-hero-module' => [
-        // it's for the enable/disable the logger functionality
         'enable' => true,
-
-        // default to true, if set to true, then you can see sample:
-        // 1. /error-preview page ( ErrorHeroModule\Controller\ErrorPreviewController )
-        // 2. error-preview command (ErrorHeroModule\Controller\ErrorPreviewConsoleController) via
-        //       php public/index.php error-preview
-        //
-        // otherwise(false), you can't see them, eg: on production env.
-        'enable-error-preview-page' => true,
-
         'display-settings' => [
 
             // excluded php errors ( http://www.php.net/manual/en/errorfunc.constants.php )
             'exclude-php-errors' => [
 
-                // can be specific error
-                \E_USER_DEPRECATED,
-
                 // can be specific error with specific message
-                [\E_WARNING, 'specific error message'],
+                [\E_NOTICE, 'Undefined offset: 1'],
 
             ],
 
             // excluded exceptions
             'exclude-exceptions' => [
 
-                // can be an Exception class or class extends Exception class
-                \App\Exception\MyException::class,
+                // can be specific exception instance with specific error message
+                [\Exception::class, 'a sample exception preview'],
 
-                // can be specific exception with specific message
-                [\RuntimeException::class, 'specific exception message'],
-
-                // or specific Error class with specific message
-                [\Error::class, 'specific error message'],
-
+                // or Error class
+                [\Error::class, 'a sample error preview'],
             ],
 
             // show or not error
@@ -87,28 +74,13 @@ return [
                 'view'   => 'error-hero-module/error-default'
             ],
 
-            // if enable and display_errors = 0, and on console env, the console will bring message for zend-mvc
+            // if enable and display_errors = 0, the console will bring message
             'console' => [
                 'message' => 'We have encountered a problem and we can not fulfill your request. An error report has been generated and sent to the support team and someone will attend to this problem urgently. Please try again later. Thank you for your patience.',
             ],
 
-            // if enable, display_errors = 0, and request XMLHttpRequest
-            // on this case, the "template" key will be ignored.
-            'ajax' => [
-                'message' => <<<json
-{
-    "type": "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html",
-    "title": "Internal Server Error",
-    "status": 500,
-    "detail": "We have encountered a problem and we can not fulfill your request. An error report has been generated and sent to the support team and someone will attend to this problem urgently. Please try again later. Thank you for your patience."
-}
-json
-            ],
-
         ],
         'logging-settings' => [
-            // time range for same error, file, line, url, message to be re-logged
-            // in seconds range, 86400 means 1 day
             'same-error-log-time-range' => 86400,
         ],
         'email-notification-settings' => [

--- a/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
+++ b/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
@@ -62,6 +62,9 @@ describe('Integration via ErrorPreviewController', function () {
 
         it('empty as rely to original mvc process to handle', function() {
 
+            @mkdir(__DIR__ . '/../Fixture/view/error-hero-module/error-preview', 0755, true);
+            file_put_contents(__DIR__ . '/../Fixture/view/error-hero-module/error-preview/notice.phtml', '');
+
             $request     = $this->application->getRequest();
             $request->setMethod('GET');
             $request->setUri('http://example.com/error-preview/notice');
@@ -72,9 +75,12 @@ describe('Integration via ErrorPreviewController', function () {
             $content = \ob_get_clean();
 
             expect(\ob_get_clean())->toBe('');
-            $this->application->getResponse()->setStatusCode(http_response_code());
-            expect($this->application->getResponse()->getStatusCode())->toBe(500);
+            // yes, excluded E_* error means it ignored, means it passed, means it is 200 status code
+            expect($this->application->getResponse()->getStatusCode())->toBe(200);
 
+            unlink(__DIR__ . '/../Fixture/view/error-hero-module/error-preview/notice.phtml');
+            rmdir(__DIR__ . '/../Fixture/view/error-hero-module/error-preview');
+            rmdir(__DIR__ . '/../Fixture/view/error-hero-module');
 
         });
 

--- a/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
+++ b/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace ErrorHeroModule\Spec;
+
+use ErrorHeroModule;
+use Zend\Console\Console;
+use Zend\Db\Adapter\AdapterInterface;
+use Zend\Db\ResultSet\ResultSet;
+use Zend\Db\TableGateway\TableGateway;
+use Zend\Mvc\Application;
+
+describe('Integration via ErrorPreviewController', function () {
+
+    given('application', function () {
+
+        Console::overrideIsConsole(false);
+
+        $application = Application::init([
+            'modules' => [
+                'Zend\Router',
+                'Zend\Db',
+                'ErrorHeroModule',
+            ],
+            'module_listener_options' => [
+                'config_glob_paths' => [
+                    \realpath(__DIR__).'/../Fixture/config/autoload-for-specific-error-and-exception/error-hero-module.local.php',
+                    \realpath(__DIR__).'/../Fixture/config/module.local.php',
+                ],
+            ],
+        ]);
+
+        $events         = $application->getEventManager();
+        $serviceManager = $application->getServiceManager();
+        $serviceManager->get('SendResponseListener')
+                       ->detach($events);
+
+        return $application;
+
+    });
+
+    describe('/error-preview', function() {
+
+        it('empty as rely to original mvc process to handle', function() {
+
+            $request     = $this->application->getRequest();
+            $request->setMethod('GET');
+            $request->setUri('http://example.com/error-preview');
+            $request->setRequestUri('/error-preview');
+
+            \ob_start();
+            $this->application->run();
+            $content = \ob_get_clean();
+
+            expect(\ob_get_clean())->toBe('');
+            expect($this->application->getResponse()->getStatusCode())->toBe(500);
+
+           // $select = $this->tableGateway->getSql()->select();
+           // echo $select->count();
+
+        });
+
+    });
+
+    describe('/error-preview/notice', function() {
+
+        it('empty as rely to original mvc process to handle', function() {
+
+            $request     = $this->application->getRequest();
+            $request->setMethod('GET');
+            $request->setUri('http://example.com/error-preview/notice');
+            $request->setRequestUri('/error-preview/notice');
+
+            \ob_start();
+            $this->application->run();
+            $content = \ob_get_clean();
+
+            expect(\ob_get_clean())->toBe('');
+            $this->application->getResponse()->setStatusCode(http_response_code());
+            expect($this->application->getResponse()->getStatusCode())->toBe(500);
+
+
+        });
+
+    });
+
+    describe('/error-preview/error', function() {
+
+        it('empty as rely to original mvc process to handle', function() {
+
+            $request     = $this->application->getRequest();
+            $request->setMethod('GET');
+            $request->setUri('http://example.com/error-preview/error');
+            $request->setRequestUri('/error-preview/error');
+
+            \ob_start();
+            $this->application->run();
+            $content = \ob_get_clean();
+
+            expect(\ob_get_clean())->toBe('');
+            expect($this->application->getResponse()->getStatusCode())->toBe(500);
+
+
+        });
+
+    });
+
+});

--- a/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
+++ b/spec/Integration/IntegrationViaErrorPreviewControllerForSpecificErrorAndExceptionSpec.php
@@ -54,9 +54,6 @@ describe('Integration via ErrorPreviewController', function () {
             expect(\ob_get_clean())->toBe('');
             expect($this->application->getResponse()->getStatusCode())->toBe(500);
 
-           // $select = $this->tableGateway->getSql()->select();
-           // echo $select->count();
-
         });
 
     });

--- a/src/Handler/Formatter/Json.php
+++ b/src/Handler/Formatter/Json.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace ErrorHeroModule\Handler\Formatter;
 
 use DateTime;
-use Zend\Log\Formatter\Json as BaseJson;
 use Zend\Log\Formatter\FormatterInterface;
+use Zend\Log\Formatter\Json as BaseJson;
 
 class Json extends BaseJson implements FormatterInterface
 {

--- a/src/HeroFunction.php
+++ b/src/HeroFunction.php
@@ -18,18 +18,21 @@ function isExcludedException(array $excludeExceptionsConfig, Throwable $t)
 {
     $exceptionOrErrorClass = \get_class($t);
 
+    $isExcluded = false;
     foreach ($excludeExceptionsConfig as $excludeException) {
         if ($exceptionOrErrorClass === $excludeException) {
-            return true;
+            $isExcluded = true;
+            break;
         }
 
         if (is_array($excludeException)
             && $excludeException[0] === $exceptionOrErrorClass
             && $excludeException[1] === $t->getMessage()
         ) {
-            return true;
+            $isExcluded = true;
+            break;
         }
     }
 
-    return false;
+    return $isExcluded;
 }

--- a/src/HeroFunction.php
+++ b/src/HeroFunction.php
@@ -5,10 +5,28 @@ declare(strict_types=1);
 namespace ErrorHeroModule;
 
 use Seld\JsonLint\JsonParser;
+use Throwable;
 
 function detectMessageContentType(string $message) : string
 {
     return (new JsonParser())->lint($message) === null
         ? 'application/problem+json'
         : ((\strip_tags($message) === $message) ? 'text/plain' : 'text/html');
+}
+
+function isExcludedException(array $excludeExceptionsConfig, Throwable $t)
+{
+    $exceptionOrErrorClass = \get_class($t);
+
+    foreach ($excludeExceptionsConfig as $excludeException) {
+        if ($exceptionOrErrorClass === $excludeException) {
+            return true;
+        }
+
+        if (is_array($excludeException) && $excludeException[0] === $exceptionOrErrorClass && $excludeException[1] === $t->getMessage()) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/src/HeroFunction.php
+++ b/src/HeroFunction.php
@@ -23,7 +23,10 @@ function isExcludedException(array $excludeExceptionsConfig, Throwable $t)
             return true;
         }
 
-        if (is_array($excludeException) && $excludeException[0] === $exceptionOrErrorClass && $excludeException[1] === $t->getMessage()) {
+        if (is_array($excludeException)
+            && $excludeException[0] === $exceptionOrErrorClass
+            && $excludeException[1] === $t->getMessage()
+        ) {
             return true;
         }
     }

--- a/src/HeroTrait.php
+++ b/src/HeroTrait.php
@@ -110,7 +110,10 @@ trait HeroTrait
                 return;
             }
 
-            if (is_array($excludePhpError) && $excludePhpError[0] === $errorType && $excludePhpError[1] === $errorMessage) {
+            if (is_array($excludePhpError)
+                && $excludePhpError[0] === $errorType
+                && $excludePhpError[1] === $errorMessage
+            ) {
                 return;
             }
         }

--- a/src/HeroTrait.php
+++ b/src/HeroTrait.php
@@ -104,7 +104,6 @@ trait HeroTrait
             return;
         }
 
-        \http_response_code(500);
         foreach ($this->errorHeroModuleConfig['display-settings']['exclude-php-errors'] as $excludePhpError) {
             if ($errorType === $excludePhpError) {
                 return;

--- a/src/HeroTrait.php
+++ b/src/HeroTrait.php
@@ -104,8 +104,15 @@ trait HeroTrait
             return;
         }
 
-        if (\in_array($errorType, $this->errorHeroModuleConfig['display-settings']['exclude-php-errors'])) {
-            return;
+        \http_response_code(500);
+        foreach ($this->errorHeroModuleConfig['display-settings']['exclude-php-errors'] as $excludePhpError) {
+            if ($errorType === $excludePhpError) {
+                return;
+            }
+
+            if (is_array($excludePhpError) && $excludePhpError[0] === $errorType && $excludePhpError[1] === $errorMessage) {
+                return;
+            }
         }
 
         throw new ErrorException($errorMessage, 0, $errorType, $errorFile, $errorLine);

--- a/src/Listener/Mvc.php
+++ b/src/Listener/Mvc.php
@@ -65,7 +65,9 @@ class Mvc extends AbstractListenerAggregate
             return;
         }
 
-        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) &&  isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $exception)) {
+        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'])
+            && isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $exception)
+        ) {
             // rely on original mvc process
             return;
         }

--- a/src/Listener/Mvc.php
+++ b/src/Listener/Mvc.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace ErrorHeroModule\Listener;
 
+use function ErrorHeroModule\detectMessageContentType;
 use ErrorHeroModule\Handler\Logging;
 use ErrorHeroModule\HeroTrait;
+use function ErrorHeroModule\isExcludedException;
 use Webmozart\Assert\Assert;
 use Zend\Console\Response as ConsoleResponse;
 use Zend\EventManager\AbstractListenerAggregate;
@@ -14,10 +16,9 @@ use Zend\Http\PhpEnvironment\Request;
 use Zend\Http\PhpEnvironment\Response;
 use Zend\Mvc\MvcEvent;
 use Zend\Stdlib\RequestInterface;
+
 use Zend\Text\Table;
 use Zend\View\Renderer\PhpRenderer;
-
-use function ErrorHeroModule\detectMessageContentType;
 
 class Mvc extends AbstractListenerAggregate
 {
@@ -64,9 +65,7 @@ class Mvc extends AbstractListenerAggregate
             return;
         }
 
-        $exceptionClass = \get_class($exception);
-        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) &&
-            \in_array($exceptionClass, $this->errorHeroModuleConfig['display-settings']['exclude-exceptions'])) {
+        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) &&  isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $exception)) {
             // rely on original mvc process
             return;
         }

--- a/src/Middleware/Expressive.php
+++ b/src/Middleware/Expressive.php
@@ -6,8 +6,10 @@ namespace ErrorHeroModule\Middleware;
 
 use Closure;
 use Error;
+use function ErrorHeroModule\detectMessageContentType;
 use ErrorHeroModule\Handler\Logging;
 use ErrorHeroModule\HeroTrait;
+use function ErrorHeroModule\isExcludedException;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -18,10 +20,9 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\HtmlResponse;
 use Zend\Expressive\Template\TemplateRendererInterface;
 use Zend\Expressive\ZendView\ZendViewRenderer;
+
 use Zend\Psr7Bridge\Psr7ServerRequest;
 use Zend\View\Model\ViewModel;
-
-use function ErrorHeroModule\detectMessageContentType;
 
 class Expressive implements MiddlewareInterface
 {
@@ -69,10 +70,7 @@ class Expressive implements MiddlewareInterface
      */
     public function exceptionError(Throwable $t) : ResponseInterface
     {
-        $exceptionOrErrorClass = \get_class($t);
-        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) &&
-            \in_array($exceptionOrErrorClass, $this->errorHeroModuleConfig['display-settings']['exclude-exceptions'])
-        ) {
+        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) && isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $t)) {
             throw $t;
         }
 

--- a/src/Middleware/Expressive.php
+++ b/src/Middleware/Expressive.php
@@ -70,7 +70,9 @@ class Expressive implements MiddlewareInterface
      */
     public function exceptionError(Throwable $t) : ResponseInterface
     {
-        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions']) && isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $t)) {
+        if (isset($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'])
+            && isExcludedException($this->errorHeroModuleConfig['display-settings']['exclude-exceptions'], $t)
+        ) {
             throw $t;
         }
 


### PR DESCRIPTION
to make it possible to exclude only with specific message, eg: 

```php
// excluded php errors ( http://www.php.net/manual/en/errorfunc.constants.php )
'exclude-php-errors' => [

    // can be specific error
    \E_USER_DEPRECATED,

    // can be specific error with specific message
    [\E_WARNING, 'specific error message'],

],

// excluded exceptions
'exclude-exceptions' => [

    // can be an Exception class or class extends Exception class
    \App\Exception\MyException::class,

    // can be specific exception with specific message
    [\RuntimeException::class, 'specific exception message'],

    // or specific Error class with specific message
    [\Error::class, 'specific error message'],

],
```